### PR TITLE
Update supported Unity versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ These are SDKs designed specifically for serving advertising content into your a
 | OpenX | 4.8.1 | |
 | RFMAdSDK | 6.4.0| |
 | Tapjoy | 12.4.2 | |
-| Unity Ads | 3.4.2 | 3.4.2-3.4.6 |
+| Unity Ads | 3.4.2 | 3.4.2-3.4.6, 3.4.8 |
 | Mopub mediation Unity |  | 3.4.6.0 |
 | Verizon | 1.5.0 | 1.2.0 |
 | Vungle | 6.5.3 | 6.7.0 - 6.8.1 |


### PR DESCRIPTION
Note: Unity has skipped 3.4.7 - it is not on their public releases page.

Pubguard SDK update [here](https://github.com/bidstack-group/pubguard-sdk-android/pull/86).