### PR TITLE
PGB-563 support table ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,26 +396,26 @@ Here is a guide based based on our compiling with our test apps, please bear in 
 
 These are SDKs designed specifically for serving advertising content into your app, if you would like information on a version or vendor that is not on this list please email support@pubguard.com
 
-| Company/Product | iOS SDK identifier | iOS versions | Android versions |
-| ------- | ----- | ------- |
-| AdColony | | 4.1.4|  4.1.0 - 4.1.4  |
-| AdMob | Google-Mobile-Ads-SDK | 7.57.0 | 19.0.0 - 19.4.0 |
-| Amazon Mobile Ads | |  | 6.0.0 |
-| AppNexus | AppNexusSDK | 7.2 |    |
-| Chartboost | | | 7.5.0; 8.1.0 |
-| Facebook Audience Network | FBAudienceNetwork | 5.8.0 | 5.8.0 - 6.0.0 |
-| InMobi | InMobiSDK | 9.0.6 | 9.0.1 |
-| ironSource | IronSourceSDK | 6.15.0.1 | 6.14.0.1; 6.16.1 |
-| MoPub |  | 5.14.0 | 5.10.0, 5.12.0 |
-| MoPub mediation - AdMob | |  |  |
-| MoPub mediation - Unity | |  | 3.4.6.0 |
-| One by AOL | MMAdSDK | 6.8.2|  |
-| OpenX | | 4.8.1 | |
-| Rubicon Project | RFMAdSDK | 6.4.0| |
-| Tapjoy | | 12.4.2 | |
-| Unity Ads | | 3.4.2 | 3.4.2-3.4.6, 3.4.8 |
-| Verizon | | 1.5.0 | 1.2.0 |
-| Vungle | | 6.5.3 | 6.7.0 - 6.8.1 |
+| Company/Product | iOS SDK identifier | iOS versions | Android SDK identifier | Android versions |
+| ------- | ----- | ------- | ------- | ------- |
+| AdColony | | 4.1.4| com.adcolony:sdk |  4.1.0 - 4.1.4  |
+| AdMob | Google-Mobile-Ads-SDK | 7.57.0 | com.google.android.gms:play-services-ads | 19.0.0 - 19.4.0 |
+| Amazon Mobile Ads | |  | com.amazon.android:mobile-ads | 6.0.0 |
+| AppNexus | AppNexusSDK | 7.2 |  |    |
+| Chartboost | | | com.chartboost:chartboost-sdk | 7.5.0; 8.1.0 |
+| Facebook Audience Network | FBAudienceNetwork | 5.8.0 | com.facebook.android:audience-network-sdk | 5.8.0 - 6.0.0 |
+| InMobi | InMobiSDK | 9.0.6 | com.inmobi.monetization:inmobi-ads | 9.0.1 |
+| ironSource | IronSourceSDK | 6.15.0.1 | com.ironsource.sdk:mediationsdk | 6.14.0.1; 6.16.1 |
+| MoPub |  | 5.14.0 | com.mopub:mopub-sdk | 5.10.0, 5.12.0 |
+| MoPub mediation - AdMob | |  | com.mopub.mediation:admob |  |
+| MoPub mediation - Unity | |  | com.mopub.mediation:unityads | 3.4.6.0 |
+| One by AOL | MMAdSDK | 6.8.2| |  |
+| OpenX | | 4.8.1 |  | |
+| Rubicon Project | RFMAdSDK | 6.4.0| | |
+| Tapjoy | | 12.4.2 |  | |
+| Unity Ads | | 3.4.2 | com.unity3d.ads:unity-ads | 3.4.2-3.4.6, 3.4.8 |
+| Verizon | | 1.5.0 | com.verizon.ads:android-vas-standard-edition | 1.2.0 |
+| Vungle | | 6.5.3 | com.vungle:publisher-sdk-android | 6.7.0 - 6.8.1 |
 
 ### Mediation Support
 


### PR DESCRIPTION
order is case insensitive + mediation after base

renamed One by AOL using the official name
minor reformatting for MoPub mediation entries

~P.S. it seems there are two distinct kinds of entries - company/service names and SDK identifiers
are there any plans to sticking with one (or both) of those consistently?~ discussed and decided to split into separate columns