### PR TITLE
PGB-610: bumped unity ads version to 3.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ These are SDKs designed specifically for serving advertising content into your a
 | OpenX | | 4.8.1 |  | |
 | Rubicon Project | RFMAdSDK | 6.4.0| | |
 | Tapjoy | | 12.4.2 |  | |
-| Unity Ads | | 3.4.2 | com.unity3d.ads:unity-ads | 3.4.2-3.4.6, 3.4.8, 3.5.0 |
+| Unity Ads | | 3.4.2 | com.unity3d.ads:unity-ads | 3.4.2 - 3.5.0 |
 | Verizon | | 1.5.0 | com.verizon.ads:android-vas-standard-edition | 1.2.0 |
 | Vungle | | 6.5.3 | com.vungle:publisher-sdk-android | 6.7.0 - 6.8.1 |
 


### PR DESCRIPTION
PR: https://github.com/bidstack-group/pubguard-sdk-android/pull/93

this kind of versioning might be getting tedious if unity will continue to skip versions like this:
https://github.com/Unity-Technologies/unity-ads-android/releases
should we perhaps just show them as a single range?