### PR TITLE
Change supported MoPub version

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ These are SDKs designed specifically for serving advertising content into your a
 | Facebook Audience Network | FBAudienceNetwork | 5.8.0 | com.facebook.android:audience-network-sdk | 5.8.0 - 6.1.0 |
 | InMobi | InMobiSDK | 9.0.6 | com.inmobi.monetization:inmobi-ads | 9.0.1; 9.1.0 |
 | ironSource | IronSourceSDK | 6.15.0.1 | com.ironsource.sdk:mediationsdk | 6.14.0.1; 6.16.1; 6.18.0 - 7.0.3 |
-| MoPub |  | 5.14.0 | com.mopub:mopub-sdk | 5.10.0, 5.12.0 |
+| MoPub |  | 5.14.0 | com.mopub:mopub-sdk | 5.14.0 |
 | MoPub mediation - AdMob | |  | com.mopub.mediation:admob |  |
 | MoPub mediation - Unity | |  | com.mopub.mediation:unityads | 3.4.6.0 |
 | One by AOL | MMAdSDK | 6.8.2| |  |


### PR DESCRIPTION
Added support for MoPub 5.14.0, removed previously supported versions (5.10.0, 5.12.0) because cid extraction was implemented incorrectly and placement id was sent instead.